### PR TITLE
Name in library.properties too long for Arduino Library Manager

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=Brzo I2C is a fast I2C Implementation written in Assembly for the esp8266
+name=Brzo I2C
 version=1.0.1
 author=Pascal Kurtansky
 maintainer=Pasko <pascal@kurtansky.ch>


### PR DESCRIPTION
Hi. I tried to submit your library to the Arduino Library Manager. They complained that the name was too long: https://github.com/arduino/Arduino/issues/5333
This pull request fixes is